### PR TITLE
Foxbit endpoint updated

### DIFF
--- a/src/variables.js
+++ b/src/variables.js
@@ -9,7 +9,7 @@ let userId = "0";
 let accountId = 0;
 let sessionToken = "";
 let OMSId = 1;
-let wsAddress = "wss://apifoxbitprod.alphapoint.com/WSGateway/";
+let wsAddress = "wss://apifoxbitprodlb.alphapoint.com/WSGateway/";
 let ws = new WebSocket(wsAddress);
 
 module.exports = {


### PR DESCRIPTION
The foxbit endpoint is outdated

Solution:

It is necessary to change the value of this variable:
`let wsAddress = "wss://apifoxbitprod.alphapoint.com/WSGateway/";`
to this value:
`let wsAddress = "wss://apifoxbitprodlb.alphapoint.com/WSGateway/";`