### PR TITLE
Updating API URL to the Foxbit's one

### DIFF
--- a/src/variables.js
+++ b/src/variables.js
@@ -9,7 +9,7 @@ let userId = "0";
 let accountId = 0;
 let sessionToken = "";
 let OMSId = 1;
-let wsAddress = "wss://apifoxbitprodlb.alphapoint.com/WSGateway/";
+let wsAddress = "wss://api.foxbit.com.br/WSGateway/";
 let ws = new WebSocket(wsAddress);
 
 module.exports = {


### PR DESCRIPTION
Just an update of our API URL, soon the older one will not be working anymore.

**New  WS API URL**: wss://api.foxbit.com.br/WSGateway/